### PR TITLE
allow usage with rails4

### DIFF
--- a/nkss-rails.gemspec
+++ b/nkss-rails.gemspec
@@ -17,7 +17,7 @@ projects so you can instantly have cute docs."
   s.files = Dir["{app,config,lib}/**/*"] + ["Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", "~> 3.2.0"
+  s.add_dependency "rails", ">= 3.2.0"
 
   s.add_dependency "kss"
   s.add_dependency "ffaker"


### PR DESCRIPTION
Loosen up the gemspec dependency to allow usage with rails4.
