### PR TITLE
fix loading external js and css files to work with https connection

### DIFF
--- a/app/views/layouts/styleguide_page.html.haml
+++ b/app/views/layouts/styleguide_page.html.haml
@@ -27,9 +27,9 @@
   %section.sg-body
     = yield
 
-  %script{src: "http://cdnjs.cloudflare.com/ajax/libs/jquery/1.8.0/jquery-1.8.0.min.js"}
-  %script{src: "http://google-code-prettify.googlecode.com/svn/trunk/src/prettify.js"}
-  %link{href: "http://google-code-prettify.googlecode.com/svn/trunk/src/prettify.css", type: "text/css", rel: "stylesheet"}
+  %script{src: "//cdnjs.cloudflare.com/ajax/libs/jquery/1.8.0/jquery-1.8.0.min.js"}
+  %script{src: "//google-code-prettify.googlecode.com/svn/trunk/src/prettify.js"}
+  %link{href: "//google-code-prettify.googlecode.com/svn/trunk/src/prettify.css", type: "text/css", rel: "stylesheet"}
   :javascript
     // Pretty printer script
     (function() {


### PR DESCRIPTION
I've encountered a error 'jQuery isn't loading and '$' is undefined', when I accessed to /styleguides with https .

this commit would fix the error.
