### PR TITLE
fixes #12

### DIFF
--- a/app/controllers/styleguides_controller.rb
+++ b/app/controllers/styleguides_controller.rb
@@ -1,5 +1,7 @@
 class StyleguidesController < ApplicationController
 
+  helper :styleguide
+
   helper_method :styleguide_options
   helper_method :styleguide_title
   helper_method :styleguide_sections


### PR DESCRIPTION
This makes my workaround obsolete. Seems to work with the default setting of config.action_controller.include_all_helpers as well.
